### PR TITLE
perf:  bring the dictionary of maximum intervals in line with the acceptable query periods

### DIFF
--- a/tinkoff/invest/utils.py
+++ b/tinkoff/invest/utils.py
@@ -24,7 +24,6 @@ __all__ = (
 
 DAYS_IN_YEAR = 365
 
-
 MAX_INTERVALS = {
     CandleInterval.CANDLE_INTERVAL_1_MIN: timedelta(days=1),
     CandleInterval.CANDLE_INTERVAL_2_MIN: timedelta(days=1),


### PR DESCRIPTION
Приведение словаря MAX_INTERVALS в соответствие с допустимыми периодами запросов исторических свечей, указанными в [документации](https://russianinvestments.github.io/investAPI/faq_marketdata/#2.5). Для CandleInterval.CANDLE_INTERVAL_30_MIN максимальный интервал изменён на timedelta(days=2), для CandleInterval.CANDLE_INTERVAL_2_HOUR и CandleInterval.CANDLE_INTERVAL_4_HOUR максимальный интервал изменён на timedelta(weeks=4), для CandleInterval.CANDLE_INTERVAL_MONTH максимальный интервал изменён на timedelta(days=DAYS_IN_YEAR * 10).
