### PR TITLE
Update get_asset_fundamentals.py

### DIFF
--- a/examples/get_asset_fundamentals.py
+++ b/examples/get_asset_fundamentals.py
@@ -9,7 +9,7 @@ TOKEN = os.environ["INVEST_TOKEN"]
 def main():
     with Client(TOKEN) as client:
         request = GetAssetFundamentalsRequest(
-            assets=["TCS00A105GE2"],
+            assets=["40d89385-a03a-4659-bf4e-d3ecba011782"],
         )
         print(client.instruments.get_asset_fundamentals(request=request))
 


### PR DESCRIPTION
UID required instead figi

В качестве входного параметра для метода нужен UID актива(assetUid), а не figi инструмента.