### PR TITLE
fix: add new order book type

### DIFF
--- a/tinkoff/invest/schemas.py
+++ b/tinkoff/invest/schemas.py
@@ -431,6 +431,7 @@ class OrderBookType(_grpc_helpers.Enum):
     ORDERBOOK_TYPE_UNSPECIFIED = 0
     ORDERBOOK_TYPE_EXCHANGE = 1
     ORDERBOOK_TYPE_DEALER = 2
+    ORDERBOOK_TYPE_ALL = 3
 
 
 class BondType(_grpc_helpers.Enum):


### PR DESCRIPTION
<!-- Опишите ваши изменения. Это ускорит процесс review.  -->
Added a new type (ORDERBOOK_TYPE_ALL) to the OrderBookType class. Order books of such type were sent to me in a market data stream causing an exception.
https://russianinvestments.github.io/investAPI/marketdata/#orderbooktype

<!-- Убедитесь, что прочитали файл https://github.com/RussianInvestments/invest-python/blob/main/CONTRIBUTING.md -->
