### PR TITLE
fix: fix a problem with MarketDataCache, when there is a last candle th…

### DIFF
--- a/tinkoff/invest/caching/market_data_cache/cache.py
+++ b/tinkoff/invest/caching/market_data_cache/cache.py
@@ -59,8 +59,8 @@ class MarketDataCache:
         from_net: Iterable[HistoricCandle],
     ) -> Iterable[HistoricCandle]:
         candles = list(from_net)
-        if candles:
-            complete_candles = list(self._filter_complete_candles(candles))
+        complete_candles = list(self._filter_complete_candles(candles))
+        if complete_candles:
             complete_candle_times = [candle.time for candle in complete_candles]
             complete_net_range = (
                 min(complete_candle_times),


### PR DESCRIPTION
If the last candle is not yet complete it is not cached.  The next time, retrieving candles, if the last candle have not yet completed, the following code 

```python
def _with_saving_into_cache(
        self,
        storage: InstrumentMarketDataStorage,
        from_net: Iterable[HistoricCandle],
    ) -> Iterable[HistoricCandle]:
        candles = list(from_net)
        if candles:
            complete_candles = list(self._filter_complete_candles(candles))
            complete_candle_times = [candle.time for candle in complete_candles]
            complete_net_range = (
                min(complete_candle_times),
                max(complete_candle_times),
            )
```

will throw an exception because `complete_candle_times` is empty and `min` of empty list is not defined. The fix is  instead of checking size of `candles` list we need to check size of `complete_candles`.



The exception traceback example:

```
Traceback (most recent call last):
  File "/Users/acheshkov/projects/portfolio_search/data.py", line 63, in <module>
    for candle in candles:
                  ^^^^^^^
  File "/Users/acheshkov/projects/portfolio_search/venv/3.12/lib/python3.12/site-packages/tinkoff/invest/utils.py", line 219, in _
    yield from filter_distinct_candles(list(f(*args, **kwargs)))
                                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/acheshkov/projects/portfolio_search/venv/3.12/lib/python3.12/site-packages/tinkoff/invest/caching/market_data_cache/cache.py", line 130, in get_all_candles
    yield from self._with_saving_into_cache(
  File "/Users/acheshkov/projects/portfolio_search/venv/3.12/lib/python3.12/site-packages/tinkoff/invest/caching/market_data_cache/cache.py", line 67, in _with_saving_into_cache
    min(complete_candle_times),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: min() iterable argument is empty
```